### PR TITLE
Bug fix to use the translated grid and to avoid infinite loops.

### DIFF
--- a/ttcr/Grid3D.h
+++ b/ttcr/Grid3D.h
@@ -287,7 +287,7 @@ namespace ttcr {
 
         virtual void dump_secondary(std::ofstream&) const {}
 
-        virtual T1 computeSlowness(const sxyz<T1>&) const {
+        virtual T1 computeSlowness(const sxyz<T1>& _Rx, const bool& is_trnslated=true) const {
             throw std::runtime_error("Method computeSlowness should be implemented in subclass");
         }
 

--- a/ttcrpy/tmesh.pxd
+++ b/ttcrpy/tmesh.pxd
@@ -31,7 +31,7 @@ cdef extern from "Grid3D.h" namespace "ttcr" nogil:
         void computeK(vector[vector[vector[siv[T1]]]]&, int, int, bool, bool, int) except +
         size_t getNthreads()
         void setSlowness(vector[T1]&) except +
-        T1 computeSlowness(sxyz[T1]&) except +
+        T1 computeSlowness(sxyz[T1]&,  bool ) except +
         void getTT(vector[T1]& tt, size_t threadNo) except +
         void raytrace(vector[sxyz[T1]]& Tx,
                       vector[T1]& t0,

--- a/ttcrpy/tmesh.pyx
+++ b/ttcrpy/tmesh.pyx
@@ -606,7 +606,8 @@ cdef class Mesh3d:
         for n in range(nTx):
             s = 0.0
             for nn in range(vTx[n].size()):
-                s += self.grid.computeSlowness(vTx[n][nn])
+                s += self.grid.computeSlowness(vTx[n][nn], False)# a parameter is added to indicate that the point is not yet translated
+                #if we chose to work in relative coordinates
             s0[iTx[n]] = s/vTx[n].size()
         return s0
 
@@ -705,11 +706,11 @@ cdef class Mesh3d:
         if src.shape[1] != 3 or rcv.shape[1] != 3:
             raise ValueError('src and rcv should be ndata x 3')
 
-        if self.is_outside(src):
-            raise ValueError('Source point outside grid')
+        # if self.is_outside(src):
+        #     raise ValueError('Source point outside grid')
 
-        if self.is_outside(rcv):
-            raise ValueError('Receiver outside grid')
+        # if self.is_outside(rcv):## this test is already made in the c++ code
+        #     raise ValueError('Receiver outside grid')
 
         if slowness is not None:
             self.set_slowness(slowness)


### PR DESCRIPTION
-	Remove the verification of the source and receiver positions in the raytrace method: it is already done when calling the c++ method and it generates a bug when using translated grids. 
-	Reimplement the method Computeslowness to consider untranslated points passed to a translated grid. 
-	Avoid infinite loops by setting a maximum number of iterations when tracing back the seismic rays. 