### PR TITLE
Add const to non-mutating reader methods

### DIFF
--- a/ttcr/MSHReader.h
+++ b/ttcr/MSHReader.h
@@ -117,7 +117,7 @@ namespace ttcr {
             return 0;
         }
 
-        size_t getNumberOfElements() {
+        size_t getNumberOfElements() const {
             std::ifstream fin(filename.c_str());
             std::string line;
             size_t nElements=0;

--- a/ttcr/VTUReader.h
+++ b/ttcr/VTUReader.h
@@ -90,7 +90,7 @@ namespace ttcr {
         }
 
 
-        size_t getNumberOfElements() {
+        size_t getNumberOfElements() const {
             vtkSmartPointer<vtkXMLUnstructuredGridReader> reader =
             vtkSmartPointer<vtkXMLUnstructuredGridReader>::New();
             reader->SetFileName(filename.c_str());
@@ -98,7 +98,7 @@ namespace ttcr {
             return reader->GetOutput()->GetNumberOfCells();
         }
 
-        size_t getNumberOfNodes() {
+        size_t getNumberOfNodes() const {
             vtkSmartPointer<vtkXMLUnstructuredGridReader> reader =
             vtkSmartPointer<vtkXMLUnstructuredGridReader>::New();
             reader->SetFileName(filename.c_str());
@@ -107,7 +107,7 @@ namespace ttcr {
         }
 
         template<typename T>
-        void readNodes2D(std::vector<sxz<T>>& nodes, const int d) {
+        void readNodes2D(std::vector<sxz<T>>& nodes, const int d) const {
             vtkSmartPointer<vtkXMLUnstructuredGridReader> reader =
             vtkSmartPointer<vtkXMLUnstructuredGridReader>::New();
             reader->SetFileName(filename.c_str());
@@ -123,7 +123,7 @@ namespace ttcr {
         }
 
         template<typename T>
-        void readNodes3D(std::vector<sxyz<T>>& nodes) {
+        void readNodes3D(std::vector<sxyz<T>>& nodes) const {
             vtkSmartPointer<vtkXMLUnstructuredGridReader> reader =
             vtkSmartPointer<vtkXMLUnstructuredGridReader>::New();
             reader->SetFileName(filename.c_str());
@@ -140,7 +140,7 @@ namespace ttcr {
         }
 
         template<typename T>
-        void readTriangleElements(std::vector<triangleElem<T>>& tri) {
+        void readTriangleElements(std::vector<triangleElem<T>>& tri) const {
             vtkSmartPointer<vtkXMLUnstructuredGridReader> reader =
             vtkSmartPointer<vtkXMLUnstructuredGridReader>::New();
             reader->SetFileName(filename.c_str());
@@ -161,7 +161,7 @@ namespace ttcr {
         }
 
         template<typename T>
-        void readTetrahedronElements(std::vector<tetrahedronElem<T>>& tet) {
+        void readTetrahedronElements(std::vector<tetrahedronElem<T>>& tet) const {
             vtkSmartPointer<vtkXMLUnstructuredGridReader> reader =
             vtkSmartPointer<vtkXMLUnstructuredGridReader>::New();
             reader->SetFileName(filename.c_str());
@@ -196,7 +196,7 @@ namespace ttcr {
         }
 
         template<typename T>
-        int readSlowness(std::vector<T>& slowness, const bool constCells=true) {
+        int readSlowness(std::vector<T>& slowness, const bool constCells=true) const {
             vtkSmartPointer<vtkXMLUnstructuredGridReader> reader =
             vtkSmartPointer<vtkXMLUnstructuredGridReader>::New();
             reader->SetFileName(filename.c_str());
@@ -275,7 +275,7 @@ namespace ttcr {
         }
 
         template<typename T>
-        int readVariable(const std::string& name, std::vector<T>& var, const bool constCells=true) {
+        int readVariable(const std::string& name, std::vector<T>& var, const bool constCells=true) const {
             vtkSmartPointer<vtkXMLUnstructuredGridReader> reader =
             vtkSmartPointer<vtkXMLUnstructuredGridReader>::New();
             reader->SetFileName(filename.c_str());


### PR DESCRIPTION
## Summary

A const-correctness audit of the C++ headers found the codebase largely const-correct — no `const_cast` anywhere, and the core `Node*`/`Cell`/`Grid` accessors are all properly `const`. The one gap was the file-reader classes, where several methods read a file (via the `filename` member) and fill output-reference parameters **without modifying any object state**, yet were not marked `const`.

## Changes

- **`VTUReader`**: `getNumberOfElements`, `getNumberOfNodes`, `readNodes2D`, `readNodes3D`, `readTriangleElements`, `readTetrahedronElements`, `readSlowness`, `readVariable` → `const`.
- **`MSHReader`**: the no-arg `getNumberOfElements()` → `const`. (Its siblings `getNumberOfNodes()`, the `getNumberOfElements(int)` overload, and the `read*` methods were already const, so this was an oversight.)

## Notes

- Const-only change, no behaviour change. Adding `const` can only widen callability (a `const` reader instance can now use these methods); it cannot break existing callers.
- Verified `MSHReader` compiles through a `const` instance. `VTUReader` requires VTK (not available in the dev env), but its changes mirror exactly the already-`const` sibling methods in the same file (`get2Ddim`, `hasVariable`), which use the identical local-reader / no-member-write pattern.

### Deliberately left unchanged
- `checkPts` / `computeD` take `pts` by value — they translate it in place by `origin`.
- `MSHReader::getPhysicalNames`/`getPhysicalIndices` are `const` and lazily fill `mutable` cache members — a legitimate pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)