### PR TITLE
Pass /std:c++17 to MSVC for Windows wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,9 @@ if platform.system() == 'Darwin':
                        '-L/opt/local/lib', '-Wl,-headerpad_max_install_names',
                        '-Wl,-syslibroot,/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk']
 elif platform.system() == 'Windows':
-    extra_compile_args = ['/O2']
+    # MSVC needs /std:c++17 explicitly; its default (C++14) lacks
+    # <memory_resource> / std::pmr used by the unstructured grid classes.
+    extra_compile_args = ['/O2', '/std:c++17']
     extra_link_args = []
     libraries = ['OpenCL']
     # GitHub runners expose vcpkg through VCPKG_INSTALLATION_ROOT; honour either


### PR DESCRIPTION
## Summary

Windows wheel builds fail to compile after #85: the unstructured grid headers now use `<memory_resource>` / `std::pmr`, which require C++17. The Windows branch of `setup.py` passed only `/O2`, leaving MSVC on its default C++14 standard, so the pmr code does not compile.

macOS and Linux already pass `-std=c++17`; this adds the MSVC equivalent (`/std:c++17`).

## Change

- `setup.py` — Windows `extra_compile_args`: `['/O2']` → `['/O2', '/std:c++17']`.

`/EHsc` is already supplied by setuptools' MSVC compiler, and the `windows-latest` CI runners (VS2022) support `/std:c++17`, so no other changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)